### PR TITLE
Keep old loadables

### DIFF
--- a/src/common/app-breakaway.tsx
+++ b/src/common/app-breakaway.tsx
@@ -30,9 +30,13 @@ import { EntriesCacheManager } from "./core";
 
 // Define lazy pages
 const ProfileContainer = loadable(() => import("./pages/profile-breakaway"));
+const OldProfileContainer = loadable(() => import("./pages/profile-functional"));
+
 const ProfilePage = (props: any) => <ProfileContainer {...props} />;
 
 const CommunityContainer = loadable(() => import("./pages/community-breakaway"));
+const OldCommunityContainer = loadable(() => import("./pages/community-functional"));
+
 const CommunityPage = (props: any) => <CommunityContainer {...props} />;
 
 const DiscoverContainer = loadable(() => import("./pages/discover"));
@@ -45,6 +49,7 @@ const AuthContainer = loadable(() => import("./pages/auth"));
 const AuthPage = (props: any) => <AuthContainer {...props} />;
 
 const SubmitContainer = loadable(() => import("./pages/submit-breakaway"));
+const OldSubmitContainer = loadable(() => import("./pages/submit"));
 const SubmitPage = (props: any) => <SubmitContainer {...props} />;
 
 const OnboardContainer = loadable(() => import("./pages/onboard"));

--- a/src/common/components/static/static-navbar.tsx
+++ b/src/common/components/static/static-navbar.tsx
@@ -11,7 +11,7 @@ export const StaticNavbar = ({ fullVersionUrl }: Props) => {
           <div className="brand">
             <a href="/">
               <img
-                src={require("../../img/logo-circle.svg")}
+                src={`https://images.ecency.com/u/${process.env.HIVE_ID}/avatar/lardge`}
                 className="logo"
                 style={{ width: "40px", height: "40px" }}
                 alt="Logo"


### PR DESCRIPTION
Keep regular Ecency loadables to prevent  SSR from not finding those in loadable stats, which would cause the server to crash